### PR TITLE
feat: `update` endpoint

### DIFF
--- a/serverless.ts
+++ b/serverless.ts
@@ -8,6 +8,7 @@
 import type { AWS } from '@serverless/typescript';
 import create from '@functions/createSwapProposal';
 import get from '@functions/getSwapProposal';
+import update from '@functions/updateSwapProposal';
 
 require('dotenv').config();
 
@@ -44,7 +45,7 @@ const serverlessConfiguration: AWS = {
     }
   },
   // import the function via paths
-  functions: { create, get },
+  functions: { create, get, update },
   package: { individually: true },
   custom: {
     stage: '${opt:stage, "dev"}',

--- a/src/functions/createSwapProposal/schema.ts
+++ b/src/functions/createSwapProposal/schema.ts
@@ -5,6 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/**
+ * Schema in the `json-schema-to-ts` format
+ * @see https://www.npmjs.com/package/json-schema-to-ts
+ */
 export default {
   type: 'object',
   properties: {

--- a/src/functions/updateSwapProposal/handler.ts
+++ b/src/functions/updateSwapProposal/handler.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { IValidatedEventAPIGatewayProxyEvent } from '@libs/api-gateway';
+import { formatJSONResponse } from '@libs/api-gateway';
+import { wrapWithConnection } from '@libs/lambda';
+
+import { validatePassword } from '@libs/util';
+import { ApiError, LambdaError } from '@libs/errors';
+import { AUTHPASSWORD_HEADER_KEY } from '@libs/constants';
+import { getProposalFromDb, updateProposalOnDb } from '@services/proposals';
+import { IUpdateProposalRequest } from '@models/update';
+import updateProposalSchema from './schema';
+
+const update: IValidatedEventAPIGatewayProxyEvent<typeof updateProposalSchema> = async (event) => {
+  const {
+    partialTx,
+    signatures,
+    version,
+  } = event.body as IUpdateProposalRequest;
+
+  const authPassword = event.headers[AUTHPASSWORD_HEADER_KEY] || '';
+  if (authPassword.length < 3) {
+    throw new LambdaError('Invalid password', ApiError.InvalidPassword);
+  }
+
+  const proposalId = event.pathParameters.proposalId;
+  const { dbProposal, dbProposalPasswordData } = await getProposalFromDb(event.mySql, proposalId);
+  if (!dbProposal) {
+    throw new LambdaError('Proposal not found', ApiError.ProposalNotFound);
+  }
+  if (!validatePassword(authPassword, dbProposalPasswordData.hashedAuthPassword, dbProposalPasswordData.authPasswordSalt)) {
+    throw new LambdaError('Incorrect password', ApiError.IncorrectPassword);
+  }
+
+  if (version !== dbProposal.version) {
+    throw new LambdaError('Version conflict', ApiError.VersionConflict);
+  }
+
+  await updateProposalOnDb(event.mySql, dbProposal, {
+    partialTx,
+    signatures,
+  });
+
+  return formatJSONResponse({ success: true });
+};
+
+export const main = wrapWithConnection(update);

--- a/src/functions/updateSwapProposal/index.ts
+++ b/src/functions/updateSwapProposal/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { handlerPath } from '@libs/handler-resolver';
+import schema from './schema';
+
+export default {
+  handler: `${handlerPath(__dirname)}/handler.main`,
+  events: [
+    {
+      http: {
+        method: 'put',
+        path: '/{proposalId}',
+        request: {
+          schemas: {
+            'application/json': schema,
+          },
+        },
+      },
+    },
+  ],
+};

--- a/src/functions/updateSwapProposal/mock.json
+++ b/src/functions/updateSwapProposal/mock.json
@@ -1,0 +1,9 @@
+{
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": {
+    "partialTx": "abc",
+    "authPassword": "abc"
+  }
+}

--- a/src/functions/updateSwapProposal/mock.json
+++ b/src/functions/updateSwapProposal/mock.json
@@ -1,9 +1,0 @@
-{
-  "headers": {
-    "Content-Type": "application/json"
-  },
-  "body": {
-    "partialTx": "abc",
-    "authPassword": "abc"
-  }
-}

--- a/src/functions/updateSwapProposal/schema.ts
+++ b/src/functions/updateSwapProposal/schema.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default {
+  type: 'object',
+  properties: {
+    partialTx: { type: 'string' },
+    signatures: { type: 'string' },
+    version: { type: 'number' },
+  },
+  required: ['partialTx', 'version'],
+} as const;

--- a/src/functions/updateSwapProposal/schema.ts
+++ b/src/functions/updateSwapProposal/schema.ts
@@ -5,11 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/**
+ * Schema in the `json-schema-to-ts` format
+ * @see https://www.npmjs.com/package/json-schema-to-ts
+ */
 export default {
   type: 'object',
   properties: {
     partialTx: { type: 'string' },
-    signatures: { type: 'string' },
+    signatures: { type: ['string', 'null'] },
     version: { type: 'number' },
   },
   required: ['partialTx', 'version'],

--- a/src/libs/constants.ts
+++ b/src/libs/constants.ts
@@ -28,6 +28,11 @@ export const HASH_ITERATIONS = 1000;
 export const HASH_KEY_SIZE = 256;
 
 /**
+ * Maximum amount of history elements stored on the proposal
+ */
+export const MAX_HISTORY_LENGTH = 4;
+
+/**
  * Name of the header that should be present when interacting with endpoints that get/update proposal data
  */
 export const AUTHPASSWORD_HEADER_KEY = 'X-Auth-Password';

--- a/src/libs/errors.ts
+++ b/src/libs/errors.ts
@@ -10,6 +10,7 @@ export enum ApiError {
   DuplicateProposalId = 'DUPLICATE_PROPOSAL_ID',
   InvalidPassword = 'INVALID_PASSWORD',
   IncorrectPassword = 'INCORRECT_PASSWORD',
+  VersionConflict = 'VERSION_CONFLICT',
   UnknownError = 'UNKNOWN_ERROR',
 }
 
@@ -18,6 +19,7 @@ export const STATUS_CODE_TABLE = {
   DUPLICATE_PROPOSAL_ID: 500,
   INVALID_PASSWORD: 400,
   INCORRECT_PASSWORD: 403,
+  VERSION_CONFLICT: 409,
   UNKNOWN_ERROR: 500,
 } as const;
 

--- a/src/models/update.ts
+++ b/src/models/update.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export interface IUpdateProposalRequest {
+    partialTx: string;
+    signatures?: string;
+    version: number;
+}

--- a/src/services/proposals.ts
+++ b/src/services/proposals.ts
@@ -9,6 +9,7 @@ import { ServerlessMysql } from 'serverless-mysql';
 import { v4 } from 'uuid';
 import { hashPassword } from '@libs/util';
 import { ApiError, LambdaError } from '@libs/errors';
+import { MAX_HISTORY_LENGTH } from '@libs/constants';
 
 export interface CreateProposalDbInputs {
   authPassword: string;
@@ -107,4 +108,36 @@ export async function getProposalFromDb(mySql: ServerlessMysql, proposalId: stri
   }
 
   return { dbProposal, dbProposalPasswordData };
+}
+
+export interface IUpdateProposalDbInputs {
+  partialTx: string,
+  signatures?: string,
+}
+
+export async function updateProposalOnDb(mySql: ServerlessMysql, current: IDbProposal, updateData: IUpdateProposalDbInputs) {
+  const proposalId = current.id;
+
+  // Checking if there was a change on the proposal data, or only on its signatures
+  let newHistory: IDbProposal['history'] | undefined;
+  if (current.partialTx !== updateData.partialTx) {
+    newHistory = [
+      { partialTx: current.partialTx, timestamp: current.timestamp },
+      ...current.history,
+    ].slice(0, MAX_HISTORY_LENGTH);
+  }
+
+  const mySqlQuery = `UPDATE proposals
+SET version=version+1, 
+  partial_tx=?, 
+  signatures=?, 
+  ${newHistory ? 'history=?,' : ''} 
+  updated_at=CURRENT_TIMESTAMP
+WHERE proposal=?;
+`;
+  const updateArray = newHistory
+    ? [updateData.partialTx, updateData.signatures, JSON.stringify(newHistory), proposalId]
+    : [updateData.partialTx, updateData.signatures, proposalId];
+
+  return mySql.query(mySqlQuery, updateArray);
 }

--- a/src/services/proposals.ts
+++ b/src/services/proposals.ts
@@ -127,14 +127,14 @@ export async function updateProposalOnDb(mySql: ServerlessMysql, current: IDbPro
     ].slice(0, MAX_HISTORY_LENGTH);
   }
 
-  const mySqlQuery = `UPDATE proposals
-SET version=version+1, 
-  partial_tx=?, 
-  signatures=?, 
-  ${newHistory ? 'history=?,' : ''} 
-  updated_at=CURRENT_TIMESTAMP
-WHERE proposal=?;
-`;
+  const mySqlQuery = 
+    `UPDATE proposals
+        SET version = version + 1
+            , partial_tx = ?
+            , signatures = ?
+            ${newHistory ? ', history = ?' : ''} 
+            , updated_at = CURRENT_TIMESTAMP
+      WHERE proposal = ?`;
   const updateArray = newHistory
     ? [updateData.partialTx, updateData.signatures, JSON.stringify(newHistory), proposalId]
     : [updateData.partialTx, updateData.signatures, proposalId];

--- a/src/services/proposals.ts
+++ b/src/services/proposals.ts
@@ -127,14 +127,13 @@ export async function updateProposalOnDb(mySql: ServerlessMysql, current: IDbPro
     ].slice(0, MAX_HISTORY_LENGTH);
   }
 
-  const mySqlQuery = 
-    `UPDATE proposals
-        SET version = version + 1
-            , partial_tx = ?
-            , signatures = ?
-            ${newHistory ? ', history = ?' : ''} 
-            , updated_at = CURRENT_TIMESTAMP
-      WHERE proposal = ?`;
+  const mySqlQuery = `UPDATE proposals
+                         SET version = version + 1
+                             , partial_tx = ?
+                             , signatures = ?
+                             ${newHistory ? ', history = ?' : ''} 
+                             , updated_at = CURRENT_TIMESTAMP
+                       WHERE proposal = ?`;
   const updateArray = newHistory
     ? [updateData.partialTx, updateData.signatures, JSON.stringify(newHistory), proposalId]
     : [updateData.partialTx, updateData.signatures, proposalId];

--- a/tests/functions/updateSwapProposal.test.ts
+++ b/tests/functions/updateSwapProposal.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { closeDbConnection, getDbConnection } from '../../src/libs/db';
+import { cleanDatabase, generateApiEvent, generateHandlerContext } from '../utils';
+import { AUTHPASSWORD_HEADER_KEY } from '../../src/libs/constants';
+import { main as update } from "@functions/updateSwapProposal/handler";
+import { getProposalFromDb, createProposalOnDb } from '@services/proposals';
+
+const mySql = getDbConnection();
+
+describe('inputs validation', () => {
+  beforeEach(async () => {
+    await cleanDatabase(mySql);
+  })
+
+  afterAll(async () => {
+    await closeDbConnection(mySql);
+  })
+
+  it('should reject for a missing password', async () => {
+    const event = generateApiEvent();
+    const context = generateHandlerContext();
+
+    const response = await update(event, context)
+    expect(response.statusCode).toStrictEqual(400);
+    expect(JSON.parse(response.body))
+      .toStrictEqual(expect.objectContaining({
+        code: 'INVALID_PASSWORD',
+        errorMessage: "Invalid password",
+      }));
+  })
+
+  it('should reject for an invalid password', async () => {
+    const event = generateApiEvent();
+    const context = generateHandlerContext();
+    event.headers[AUTHPASSWORD_HEADER_KEY] = 'ab';
+
+    const response = await update(event, context)
+    expect(response.statusCode).toStrictEqual(400);
+    expect(JSON.parse(response.body))
+      .toStrictEqual(expect.objectContaining({
+        code: 'INVALID_PASSWORD',
+        errorMessage: "Invalid password",
+      }));
+  })
+
+  it('should inform of a proposal not found', async () => {
+    const event = generateApiEvent();
+    const context = generateHandlerContext();
+    event.pathParameters = { proposalId: 'non-existent' };
+    event.headers[AUTHPASSWORD_HEADER_KEY] = 'abc';
+
+    const response = await update(event, context)
+    expect(response.statusCode).toStrictEqual(404);
+    expect(JSON.parse(response.body))
+      .toStrictEqual(expect.objectContaining({
+        code: 'PROPOSAL_NOT_FOUND',
+        errorMessage: "Proposal not found",
+      }));
+  })
+
+  it('should reject for an incorrect password', async () => {
+    // Creating the proposal
+    const { proposalId } = await createProposalOnDb(mySql, {
+      partialTx: 'abc',
+      authPassword: '123',
+    });
+
+    const event = generateApiEvent();
+    const context = generateHandlerContext();
+    event.pathParameters = { proposalId };
+    event.headers[AUTHPASSWORD_HEADER_KEY] = '456';
+
+    const response = await update(event, context)
+    expect(response.statusCode).toStrictEqual(403);
+    expect(JSON.parse(response.body))
+      .toStrictEqual(expect.objectContaining({
+        code: 'INCORRECT_PASSWORD',
+        errorMessage: "Incorrect password",
+      }));
+  })
+
+  it('should reject for a conflicting version', async () => {
+    // Creating the proposal
+    const password = '123';
+    const { proposalId } = await createProposalOnDb(mySql, {
+      partialTx: 'abc1',
+      authPassword: password,
+    });
+
+    // Generating the request
+    const event = generateApiEvent();
+    const context = generateHandlerContext();
+    event.pathParameters = { proposalId };
+    event.headers[AUTHPASSWORD_HEADER_KEY] = password;
+    event.body = { partialTx: 'abc2', version: 1 };
+    const response = await update(event, context)
+
+    // Validating the response
+    expect(response.statusCode).toStrictEqual(409);
+    expect(JSON.parse(response.body))
+      .toStrictEqual(expect.objectContaining({
+        code: 'VERSION_CONFLICT',
+        errorMessage: "Version conflict",
+      }));
+  })
+})
+
+describe('successful updates', () => {
+  beforeEach(async () => {
+    await cleanDatabase(mySql);
+  })
+
+  afterAll(async () => {
+    await closeDbConnection(mySql);
+  })
+
+  it('should update the proposal data', async () => {
+    // Creating the proposal
+    const password = '123';
+    const { proposalId } = await createProposalOnDb(mySql, {
+      partialTx: 'abc1',
+      authPassword: password,
+    });
+
+    // Generating the request
+    const event = generateApiEvent();
+    const context = generateHandlerContext();
+    event.pathParameters = { proposalId };
+    event.headers[AUTHPASSWORD_HEADER_KEY] = password;
+    event.body = { partialTx: 'abc2', version: 0 };
+    const response = await update(event, context)
+
+    // Validating the response
+    expect(JSON.parse(response.body)).toStrictEqual({ success: true });
+    expect(response.statusCode).toStrictEqual(200);
+
+    // Validating the database
+    const { dbProposal } = await getProposalFromDb(mySql, proposalId);
+    expect(dbProposal).toStrictEqual({
+      id: proposalId,
+      partialTx: "abc2",
+      signatures: null,
+      timestamp: expect.any(String),
+      version: 1,
+      history: [
+        {
+          partialTx: "abc1",
+          timestamp: expect.any(String),
+        }
+      ]
+    })
+  })
+
+  it('should have the history in descending order', async () => {
+    const updateWith = ({ partialTx, version }) => {
+
+      // Generating the request
+      const event = generateApiEvent();
+      const context = generateHandlerContext();
+      event.pathParameters = { proposalId };
+      event.headers[AUTHPASSWORD_HEADER_KEY] = password;
+      event.body = { partialTx, version };
+      return update(event, context)
+    }
+
+    // Creating the proposal
+    const password = '123';
+    const { proposalId } = await createProposalOnDb(mySql, {
+      partialTx: 'abc1',
+      authPassword: password,
+    });
+
+    // Validating the response
+    await updateWith({ partialTx: 'abc2', version: 0 });
+    await updateWith({ partialTx: 'abc3', version: 1 });
+
+    // Validating the database
+    const { dbProposal } = await getProposalFromDb(mySql, proposalId);
+    expect(dbProposal).toStrictEqual({
+      id: proposalId,
+      partialTx: "abc3",
+      signatures: null,
+      timestamp: expect.any(String),
+      version: 2,
+      history: [
+        {
+          partialTx: "abc2",
+          timestamp: expect.any(String),
+        },
+        {
+          partialTx: "abc1",
+          timestamp: expect.any(String),
+        }
+      ]
+    })
+  })
+
+  it('should have the history limited to 4', async () => {
+    const updateWith = ({ partialTx, version }) => {
+
+      // Generating the request
+      const event = generateApiEvent();
+      const context = generateHandlerContext();
+      event.pathParameters = { proposalId };
+      event.headers[AUTHPASSWORD_HEADER_KEY] = password;
+      event.body = { partialTx, version };
+      return update(event, context)
+    }
+
+    // Creating the proposal
+    const password = '123';
+    const { proposalId } = await createProposalOnDb(mySql, {
+      partialTx: 'abc1',
+      authPassword: password,
+    });
+
+    // Validating the response
+    await updateWith({ partialTx: 'abc2', version: 0 });
+    await updateWith({ partialTx: 'abc3', version: 1 });
+    await updateWith({ partialTx: 'abc4', version: 2 });
+    await updateWith({ partialTx: 'abc5', version: 3 });
+    await updateWith({ partialTx: 'abc6', version: 4 });
+
+    // Validating the database
+    const { dbProposal } = await getProposalFromDb(mySql, proposalId);
+    expect(dbProposal).toStrictEqual({
+      id: proposalId,
+      partialTx: "abc6",
+      signatures: null,
+      timestamp: expect.any(String),
+      version: 5,
+      history: [
+        {
+          partialTx: "abc5",
+          timestamp: expect.any(String),
+        },
+        {
+          partialTx: "abc4",
+          timestamp: expect.any(String),
+        },
+        {
+          partialTx: "abc3",
+          timestamp: expect.any(String),
+        },
+        {
+          partialTx: "abc2",
+          timestamp: expect.any(String),
+        }
+      ]
+    })
+  })
+
+  it('should not update history when only adding signatures', async () => {
+    const updateWith = ({ partialTx, signatures, version }:
+      { partialTx: string, signatures?: string, version: number }) => {
+
+      // Generating the request
+      const event = generateApiEvent();
+      const context = generateHandlerContext();
+      event.pathParameters = { proposalId };
+      event.headers[AUTHPASSWORD_HEADER_KEY] = password;
+      event.body = { partialTx, signatures, version };
+      return update(event, context)
+    }
+
+    // Creating the proposal
+    const password = '123';
+    const { proposalId } = await createProposalOnDb(mySql, {
+      partialTx: 'abc1',
+      authPassword: password,
+    });
+
+    // Validating the response
+    await updateWith({ partialTx: 'abc2', version: 0 });
+    await updateWith({ partialTx: 'abc2', signatures: 'sigs', version: 1 });
+
+    // Validating the database
+    const { dbProposal } = await getProposalFromDb(mySql, proposalId);
+    expect(dbProposal).toStrictEqual({
+      id: proposalId,
+      partialTx: "abc2",
+      signatures: "sigs",
+      timestamp: expect.any(String),
+      version: 2,
+      history: [
+        {
+          partialTx: "abc1",
+          timestamp: expect.any(String),
+        }
+      ]
+    })
+  })
+})


### PR DESCRIPTION
# Summary
Adds the `update` endpoint to the service

# Acceptance criteria
- The client must be able to send updated `PartialTx` and `signatures` properties through the `update` endpoint successfully
- To prevent conflicts, the `version` number must match what is currently on the database at the time of the update
- The following `get` requests must return this updated contents
- Up to 4 previous `PartialTx` serializations must be stored on history
- The password must be the same used on `create`, and cannot be changed